### PR TITLE
Scrape to archive

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,17 @@
+# It's easy to add more libraries or choose different versions. Any libraries
+# specified here will be installed and made available to your morph.io scraper.
+# Find out more: https://morph.io/documentation/ruby
+
+source 'https://rubygems.org'
+
+ruby '2.3.3'
+
+git_source(:github) { |repo_name| "https://github.com/#{repo_name}.git" }
+
+gem 'scraperwiki', github: 'openaustralia/scraperwiki-ruby',
+                   branch: 'morph_defaults'
+gem 'pry'
+gem 'nokogiri'
+gem 'open-uri-cached'
+gem 'scraped', github: 'everypolitician/scraped'
+gem 'scraped_page_archive', github: 'everypolitician/scraped_page_archive'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,79 @@
+GIT
+  remote: https://github.com/everypolitician/scraped.git
+  revision: f2b7a5063e920864851b6142ebceb51f8ef62c50
+  specs:
+    scraped (0.1.0)
+      field_serializer (>= 0.3.0)
+      nokogiri
+      require_all
+
+GIT
+  remote: https://github.com/everypolitician/scraped_page_archive.git
+  revision: 28f93d74b1c11ef01463ad0e7f874050d2e7fc73
+  specs:
+    scraped_page_archive (0.5.0)
+      git (~> 1.3.0)
+      vcr-archive (~> 0.3.0)
+
+GIT
+  remote: https://github.com/openaustralia/scraperwiki-ruby.git
+  revision: fc50176812505e463077d5c673d504a6a234aa78
+  branch: morph_defaults
+  specs:
+    scraperwiki (3.0.1)
+      httpclient
+      sqlite_magic
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.5.0)
+      public_suffix (~> 2.0, >= 2.0.2)
+    coderay (1.1.1)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
+    field_serializer (0.3.0)
+    git (1.3.0)
+    hashdiff (0.3.1)
+    httpclient (2.8.3)
+    method_source (0.8.2)
+    mini_portile2 (2.1.0)
+    nokogiri (1.6.8.1)
+      mini_portile2 (~> 2.1.0)
+    open-uri-cached (0.0.5)
+    pry (0.10.4)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
+    public_suffix (2.0.4)
+    require_all (1.3.3)
+    safe_yaml (1.0.4)
+    slop (3.6.0)
+    sqlite3 (1.3.12)
+    sqlite_magic (0.0.6)
+      sqlite3
+    vcr (3.0.3)
+    vcr-archive (0.3.0)
+      vcr (~> 3.0.2)
+      webmock (~> 2.0.3)
+    webmock (2.0.3)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  nokogiri
+  open-uri-cached
+  pry
+  scraped!
+  scraped_page_archive!
+  scraperwiki!
+
+RUBY VERSION
+   ruby 2.3.3p222
+
+BUNDLED WITH
+   1.13.6

--- a/lib/english_members.page.rb
+++ b/lib/english_members.page.rb
@@ -1,6 +1,6 @@
 require 'scraped'
 
-class MembersPage < Scraped::HTML
+class EnglishMembersPage < Scraped::HTML
   field :member_urls do
     noko.xpath('//table[@id="members"]/tbody/tr/td/b/a/@href').map do |row|
       URI.join(url,row.text).to_s

--- a/lib/icelandic_members_page.rb
+++ b/lib/icelandic_members_page.rb
@@ -1,0 +1,9 @@
+require 'scraped'
+
+class IcelandicMembersPage < Scraped::HTML
+  field :member_urls do
+    noko.xpath('//table[@id="t_thingmenn"]/tbody/tr/td/span/a/@href').map do |row|
+      URI.join(url,row.text).to_s
+    end
+  end
+end

--- a/lib/members_page.rb
+++ b/lib/members_page.rb
@@ -1,0 +1,9 @@
+require 'scraped'
+
+class MembersPage < Scraped::HTML
+  field :member_urls do
+    noko.xpath('//table[@id="members"]/tbody/tr/td/b/a/@href').map do |row|
+      URI.join(url,row.text).to_s
+    end
+  end
+end

--- a/scraper.rb
+++ b/scraper.rb
@@ -6,7 +6,7 @@ require 'scraped_page_archive/open-uri'
 require_rel 'lib'
 
 urls = {
-  EnglishMembersPage => [ 'http://www.althingi.is/altext/cv/en/'],
+  EnglishMembersPage => ['http://www.althingi.is/altext/cv/en/'],
   IcelandicMembersPage => [
     'http://www.althingi.is/thingmenn/althingismenn/',
     'http://www.althingi.is/thingmenn/thingmenn/varamenn-sem-sitja-a-althingi/',
@@ -21,9 +21,9 @@ end
 urls.each do |key, urls|
   urls.each do |url|
     scraped_page_for(url, key)
-               .member_urls
-               .each do |url|
-                 _ = scraped_page_for(url)
-               end
+      .member_urls
+      .each do |url|
+      _ = scraped_page_for(url)
+    end
   end
 end

--- a/scraper.rb
+++ b/scraper.rb
@@ -14,13 +14,13 @@ urls = {
   ]
 }
 
-def scraped_page_for(url)
-  Scraped::HTML.new(response: Scraped::Request.new(url: url).response)
+def scraped_page_for(url, klass = Scraped::HTML)
+  klass.new(response: Scraped::Request.new(url: url).response)
 end
 
 urls.each do |key, urls|
   urls.each do |url|
-    key.new(response: Scraped::Request.new(url: url).response)
+    scraped_page_for(url, key)
                .member_urls
                .each do |url|
                  _ = scraped_page_for(url)

--- a/scraper.rb
+++ b/scraper.rb
@@ -7,10 +7,10 @@ require_rel 'lib'
 
 english_url = 'http://www.althingi.is/altext/cv/en/'
 icelandic_urls = {
-        members: 'http://www.althingi.is/thingmenn/althingismenn/',
-        alternates: 'http://www.althingi.is/thingmenn/thingmenn/varamenn-sem-sitja-a-althingi/',
-        substitues: 'http://www.althingi.is/thingmenn/thingmenn/varamenn-sem-hafa-tekid-saeti/'
-        }
+  members: 'http://www.althingi.is/thingmenn/althingismenn/',
+  alternates: 'http://www.althingi.is/thingmenn/thingmenn/varamenn-sem-sitja-a-althingi/',
+  substitues: 'http://www.althingi.is/thingmenn/thingmenn/varamenn-sem-hafa-tekid-saeti/'
+}
 
 def scraped_page_for(url)
   Scraped::HTML.new(response: Scraped::Request.new(url: url).response)

--- a/scraper.rb
+++ b/scraper.rb
@@ -13,7 +13,6 @@ icelandic_urls = {
         }
 
 def scraped_page_for(url)
-  puts "Opening: #{url}"
   _ = Scraped::HTML.new(response: Scraped::Request.new(url: url).response)
 end
 

--- a/scraper.rb
+++ b/scraper.rb
@@ -18,8 +18,8 @@ def scraped_page_for(url, klass = Scraped::HTML)
   klass.new(response: Scraped::Request.new(url: url).response)
 end
 
-members_pages.each do |key, _page_urls|
-  urls.each do |page_url|
+members_pages.each do |key, page_urls|
+  page_urls.each do |page_url|
     scraped_page_for(page_url, key)
       .member_urls
       .each do |member_url|

--- a/scraper.rb
+++ b/scraper.rb
@@ -5,7 +5,7 @@ require 'scraped_page_archive/open-uri'
 
 require_rel 'lib'
 
-urls = {
+members_pages = {
   EnglishMembersPage => ['http://www.althingi.is/altext/cv/en/'],
   IcelandicMembersPage => [
     'http://www.althingi.is/thingmenn/althingismenn/',
@@ -18,12 +18,12 @@ def scraped_page_for(url, klass = Scraped::HTML)
   klass.new(response: Scraped::Request.new(url: url).response)
 end
 
-urls.each do |key, urls|
-  urls.each do |url|
-    scraped_page_for(url, key)
+members_pages.each do |key, _page_urls|
+  urls.each do |page_url|
+    scraped_page_for(page_url, key)
       .member_urls
-      .each do |url|
-      _ = scraped_page_for(url)
+      .each do |member_url|
+      _ = scraped_page_for(member_url)
     end
   end
 end

--- a/scraper.rb
+++ b/scraper.rb
@@ -13,19 +13,19 @@ icelandic_urls = {
         }
 
 def scraped_page_for(url)
-  _ = Scraped::HTML.new(response: Scraped::Request.new(url: url).response)
+  Scraped::HTML.new(response: Scraped::Request.new(url: url).response)
 end
 
 EnglishMembersPage.new(response: Scraped::Request.new(url: english_url).response)
                   .member_urls
                   .each do |url|
-                    scraped_page_for(url)
+                    _ = scraped_page_for(url)
                   end
 
 icelandic_urls.each do |key, url|
   IcelandicMembersPage.new(response: Scraped::Request.new(url: url).response)
              .member_urls
              .each do |url|
-               scraped_page_for(url)
+               _ = scraped_page_for(url)
              end
 end

--- a/scraper.rb
+++ b/scraper.rb
@@ -6,8 +6,8 @@ require 'scraped_page_archive/open-uri'
 require_rel 'lib'
 
 urls = {
-  EnglishMembersPage: [ 'http://www.althingi.is/altext/cv/en/'],
-  IcelandicMembersPage: [
+  EnglishMembersPage => [ 'http://www.althingi.is/altext/cv/en/'],
+  IcelandicMembersPage => [
     'http://www.althingi.is/thingmenn/althingismenn/',
     'http://www.althingi.is/thingmenn/thingmenn/varamenn-sem-sitja-a-althingi/',
     'http://www.althingi.is/thingmenn/thingmenn/varamenn-sem-hafa-tekid-saeti/'
@@ -20,7 +20,7 @@ end
 
 urls.each do |key, urls|
   urls.each do |url|
-    eval(key.to_s).new(response: Scraped::Request.new(url: url).response)
+    key.new(response: Scraped::Request.new(url: url).response)
                .member_urls
                .each do |url|
                  _ = scraped_page_for(url)

--- a/scraper.rb
+++ b/scraper.rb
@@ -5,17 +5,28 @@ require 'scraped_page_archive/open-uri'
 
 require_rel 'lib'
 
-# url = 'http://www.althingi.is/altext/cv/en/'
+english_url = 'http://www.althingi.is/altext/cv/en/'
 icelandic_urls = {
         members: 'http://www.althingi.is/thingmenn/althingismenn/',
         alternates: 'http://www.althingi.is/thingmenn/thingmenn/varamenn-sem-sitja-a-althingi/',
         substitues: 'http://www.althingi.is/thingmenn/thingmenn/varamenn-sem-hafa-tekid-saeti/'
         }
 
+def scraped_page_for(url)
+  puts "Opening: #{url}"
+  Scraped::HTML.new(response: Scraped::Request.new(url: url).response)
+end
+
+EnglishMembersPage.new(response: Scraped::Request.new(url: english_url).response)
+                  .member_urls
+                  .each do |url|
+                    scraped_page_for(url)
+                  end
+
 icelandic_urls.each do |key, url|
   IcelandicMembersPage.new(response: Scraped::Request.new(url: url).response)
              .member_urls
              .each do |url|
-               Scraped::HTML.new(response: Scraped::Request.new(url: url).response)
+               scraped_page_for(url)
              end
 end

--- a/scraper.rb
+++ b/scraper.rb
@@ -5,27 +5,25 @@ require 'scraped_page_archive/open-uri'
 
 require_rel 'lib'
 
-english_url = 'http://www.althingi.is/altext/cv/en/'
-icelandic_urls = {
-  members: 'http://www.althingi.is/thingmenn/althingismenn/',
-  alternates: 'http://www.althingi.is/thingmenn/thingmenn/varamenn-sem-sitja-a-althingi/',
-  substitues: 'http://www.althingi.is/thingmenn/thingmenn/varamenn-sem-hafa-tekid-saeti/'
+urls = {
+  EnglishMembersPage: [ 'http://www.althingi.is/altext/cv/en/'],
+  IcelandicMembersPage: [
+    'http://www.althingi.is/thingmenn/althingismenn/',
+    'http://www.althingi.is/thingmenn/thingmenn/varamenn-sem-sitja-a-althingi/',
+    'http://www.althingi.is/thingmenn/thingmenn/varamenn-sem-hafa-tekid-saeti/'
+  ]
 }
 
 def scraped_page_for(url)
   Scraped::HTML.new(response: Scraped::Request.new(url: url).response)
 end
 
-EnglishMembersPage.new(response: Scraped::Request.new(url: english_url).response)
-                  .member_urls
-                  .each do |url|
-                    _ = scraped_page_for(url)
-                  end
-
-icelandic_urls.each do |key, url|
-  IcelandicMembersPage.new(response: Scraped::Request.new(url: url).response)
-             .member_urls
-             .each do |url|
-               _ = scraped_page_for(url)
-             end
+urls.each do |key, urls|
+  urls.each do |url|
+    eval(key.to_s).new(response: Scraped::Request.new(url: url).response)
+               .member_urls
+               .each do |url|
+                 _ = scraped_page_for(url)
+               end
+  end
 end

--- a/scraper.rb
+++ b/scraper.rb
@@ -6,15 +6,16 @@ require 'scraped_page_archive/open-uri'
 require_rel 'lib'
 
 # url = 'http://www.althingi.is/altext/cv/en/'
-urls = ['http://www.althingi.is/thingmenn/althingismenn/', # members
-        'http://www.althingi.is/thingmenn/thingmenn/varamenn-sem-sitja-a-althingi/', # alternates
-        'http://www.althingi.is/thingmenn/thingmenn/varamenn-sem-hafa-tekid-saeti/'] # substitues
+icelandic_urls = {
+        members: 'http://www.althingi.is/thingmenn/althingismenn/',
+        alternates: 'http://www.althingi.is/thingmenn/thingmenn/varamenn-sem-sitja-a-althingi/',
+        substitues: 'http://www.althingi.is/thingmenn/thingmenn/varamenn-sem-hafa-tekid-saeti/'
+        }
 
-urls.each do |url|
+icelandic_urls.each do |key, url|
   IcelandicMembersPage.new(response: Scraped::Request.new(url: url).response)
              .member_urls
              .each do |url|
-               puts "Opening: #{url}"
                Scraped::HTML.new(response: Scraped::Request.new(url: url).response)
              end
 end

--- a/scraper.rb
+++ b/scraper.rb
@@ -14,7 +14,7 @@ icelandic_urls = {
 
 def scraped_page_for(url)
   puts "Opening: #{url}"
-  Scraped::HTML.new(response: Scraped::Request.new(url: url).response)
+  _ = Scraped::HTML.new(response: Scraped::Request.new(url: url).response)
 end
 
 EnglishMembersPage.new(response: Scraped::Request.new(url: english_url).response)

--- a/scraper.rb
+++ b/scraper.rb
@@ -1,0 +1,14 @@
+require 'pry'
+require 'require_all'
+require 'scraped'
+require 'scraped_page_archive/open-uri'
+
+require_rel 'lib'
+
+url = 'http://www.althingi.is/altext/cv/en/'
+MembersPage.new(response: Scraped::Request.new(url: url).response)
+           .member_urls
+           .each do |url|
+             Scraped::HTML.new(response: Scraped::Request.new(url: url).response)
+             puts "Opening: #{url}"
+           end

--- a/scraper.rb
+++ b/scraper.rb
@@ -5,10 +5,16 @@ require 'scraped_page_archive/open-uri'
 
 require_rel 'lib'
 
-url = 'http://www.althingi.is/altext/cv/en/'
-MembersPage.new(response: Scraped::Request.new(url: url).response)
-           .member_urls
-           .each do |url|
-             Scraped::HTML.new(response: Scraped::Request.new(url: url).response)
-             puts "Opening: #{url}"
-           end
+# url = 'http://www.althingi.is/altext/cv/en/'
+urls = ['http://www.althingi.is/thingmenn/althingismenn/', # members
+        'http://www.althingi.is/thingmenn/thingmenn/varamenn-sem-sitja-a-althingi/', # alternates
+        'http://www.althingi.is/thingmenn/thingmenn/varamenn-sem-hafa-tekid-saeti/'] # substitues
+
+urls.each do |url|
+  IcelandicMembersPage.new(response: Scraped::Request.new(url: url).response)
+             .member_urls
+             .each do |url|
+               puts "Opening: #{url}"
+               Scraped::HTML.new(response: Scraped::Request.new(url: url).response)
+             end
+end


### PR DESCRIPTION
An election has recently been held for this legislature ([29/10/2016](http://www.ipu.org/parline-e/Modlist.asp)).

The data is currently scraped from Wikipedia but the Wikipedia pages have not been updated for the new term. This PR uses http://www.althingi.is as the source for the new term.

The purpose of this PR is to visit each member page belonging to members listed on the Congressmen, Substitutes and Alternates pages so that each page is saved to the archive.

## [Scraper Change checklist](https://github.com/everypolitician/everypolitician/wiki/Scraper-Change-checklist)
* [x] 1. scraper is on Morph.io under the "everypolitician-scrapers" group?
* [x] 2. scraper's GitHub "Website" link points at morph.io page?
* [x] 3. scraper is set to auto-run?
* [x] 4. scraper is archiving?
* [x] 5. legislature has a scraper webhook set? #